### PR TITLE
arch: Make changes needed for the new premake build structure

### DIFF
--- a/yaml-cpp.lua
+++ b/yaml-cpp.lua
@@ -1,217 +1,37 @@
 project "yaml-cpp"
 
-  local prj = project()
-  local prjDir = prj.basedir
+dofile(_BUILD_DIR .. "/static_library.lua")
 
-  -- -------------------------------------------------------------
-  -- project
-  -- -------------------------------------------------------------
+configuration { "*" }
 
-  -- common project settings
+uuid "7AFE0D10-6046-4248-AC3C-AA09469A2125"
 
-  dofile (_BUILD_DIR .. "/3rdparty_static_project.lua")
+includedirs {
+  "include",
+}
 
-  -- project specific settings
+files {
+  "src/*.h",
+  "src/*.cpp"
+}
 
-  uuid "7AFE0D10-6046-4248-AC3C-AA09469A2125"
+if (_PLATFORM_ANDROID) then
+end
 
-  flags {
-    "NoPCH",
-  }
+if (_PLATFORM_COCOA) then
+end
 
-  includedirs {
-    prjDir,
-    prjDir .. "/include"
-  }
+if (_PLATFORM_IOS) then
+end
 
-  files {
-    "src/*.h",
-    "src/*.cpp"
-  }
+if (_PLATFORM_LINUX) then
+end
 
-  -- -------------------------------------------------------------
-  -- configurations
-  -- -------------------------------------------------------------
+if (_PLATFORM_MACOS) then
+end
 
-  if (_PLATFORM_WINDOWS) then
-    -- -------------------------------------------------------------
-    -- configuration { "windows" }
-    -- -------------------------------------------------------------
+if (_PLATFORM_WINDOWS) then
+end
 
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/3rdparty_static_win.lua")
-
-    -- project specific configuration settings
-
-    configuration { "windows" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "windows", "Debug", "x32" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_win_x86_debug.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "windows", "Debug", "x32" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "windows", "Debug", "x64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_win_x64_debug.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "windows", "Debug", "x64" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "windows", "Release", "x32" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_win_x86_release.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "windows", "Release", "x32" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "windows", "Release", "x64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_win_x64_release.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "windows", "Release", "x64" }
-
-    -- -------------------------------------------------------------
-  end
-
-  if (_PLATFORM_LINUX) then
-    -- -------------------------------------------------------------
-    -- configuration { "linux" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_linux.lua")
-
-    -- project specific configuration settings
-
-    configuration { "linux" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "linux", "Debug", "x64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_linux_x64_debug.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "linux", "Debug", "x64" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "linux", "Release", "x64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_linux_x64_release.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "linux", "Release", "x64" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "linux", "Debug", "ARM64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_linux_arm64_debug.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "linux", "Debug", "ARM64" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "linux", "Release", "ARM64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_linux_arm64_release.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "linux", "Release", "ARM64" }
-
-    -- -------------------------------------------------------------
-  end
-
-  if (_PLATFORM_MACOS) then
-    -- -------------------------------------------------------------
-    -- configuration { "macosx" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_mac.lua")
-
-    -- project specific configuration settings
-
-    configuration { "macosx" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "macosx", "Debug", "x64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_mac_x64_debug.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "macosx", "Debug", "x64" }
-
-    -- -------------------------------------------------------------
-    -- configuration { "macosx", "Release", "x64" }
-    -- -------------------------------------------------------------
-
-    -- common configuration settings
-
-    dofile (_BUILD_DIR .. "/static_mac_x64_release.lua")
-
-    -- project specific configuration settings
-
-    -- configuration { "macosx", "Release", "x64" }
-
-    -- -------------------------------------------------------------
-  end
-
-  if (_IS_QT) then
-    -- -------------------------------------------------------------
-    -- configuration { "qt" }
-    -- -------------------------------------------------------------
-
-    local qt_include_dirs = PROJECT_INCLUDE_DIRS
-
-    -- Add additional QT include dirs
-    -- table.insert(qt_include_dirs, <INCLUDE_PATH>)
-
-    createqtfiles(project(), qt_include_dirs)
-
-    -- -------------------------------------------------------------
-  end
+if (_PLATFORM_WINUWP) then
+end


### PR DESCRIPTION
The premake build structure has been simplified and rewritten to reduce
the boilerplate needed to add additional configurations while forcing
the unique settings of a project to be defined. Migrate some defines
and compiler options to the global settings and remove all the old
boilerplate from this project.

Issue-number: https://devtopia.esri.com/runtime/devops/issues/830